### PR TITLE
Rename PERCENTAGE constant

### DIFF
--- a/const.py
+++ b/const.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_TEMPERATURE,
     TEMP_CELSIUS,
-    UNIT_PERCENTAGE,
+    PERCENTAGE,
 )
 
 API_CO2 = "carbon_dioxide"
@@ -49,14 +49,14 @@ SENSOR_TYPES = {
     API_SCORE: {
         ATTR_DEVICE_CLASS: None,
         ATTR_ICON: "mdi:blur",
-        ATTR_UNIT: UNIT_PERCENTAGE,
+        ATTR_UNIT: PERCENTAGE,
         ATTR_LABEL: "Awair score",
         ATTR_UNIQUE_ID: "score",  # matches legacy format
     },
     API_HUMID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
         ATTR_ICON: None,
-        ATTR_UNIT: UNIT_PERCENTAGE,
+        ATTR_UNIT: PERCENTAGE,
         ATTR_LABEL: "Humidity",
         ATTR_UNIQUE_ID: "HUMID",  # matches legacy format
     },


### PR DESCRIPTION
The constant has been renamed in HA 0.115 and triggers an exception in latest HA.

See https://github.com/home-assistant/core/issues/40207