### PR TITLE
Initial attempt at local+remote integration

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -2,12 +2,12 @@
 
 from typing import Optional
 
-from python_awair_local_sensors import AwairLocal
-from python_awair_local_sensors.exceptions import AwairError
+from python_awair import Awair, AwairLocal
+from python_awair.exceptions import AuthError, AwairError
 import voluptuous as vol
 
-from homeassistant.config_entries import CONN_CLASS_LOCAL_POLL, ConfigFlow
-from homeassistant.const import CONF_HOSTS
+from homeassistant.config_entries import CONN_CLASS_CLOUD_POLL, ConfigFlow, CONN_CLASS_LOCAL_POLL
+from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, LOGGER  # pylint: disable=unused-import
@@ -16,21 +16,75 @@ from .const import DOMAIN, LOGGER  # pylint: disable=unused-import
 class AwairFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for Awair."""
 
-    VERSION = 1
-    CONNECTION_CLASS = CONN_CLASS_LOCAL_POLL
+    VERSION = 2
+    CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
+
+    async def async_step_zeroconf(self, zeroconf_info):
+        """Set up locally discovered devices."""
+        ip_addr = zeroconf_info.get("host", None)
+        hostname = zeroconf_info.get("hostname", None)
+        if ip_addr is None or hostname is None:
+            # TODO: fixme
+            return self.async_abort(reason="unknown")
+
+        device = await self._get_local_info(ip_addr)
+        if device is None:
+            # TODO: fixme
+            return self.async_abort(reason="unknown")
+
+        await self.async_set_unique_id(device.uuid)
+        self._abort_if_unique_id_configured()
+
+        self.local_device = device
+        self.local_name = hostname.split(".")[0]
+        self.context["title_placeholders"] = {
+            "name": self.local_name
+        }
+        LOGGER.debug(self.local_device)
+        LOGGER.debug(self.local_name)
+        LOGGER.debug(self.context)
+        return await self.async_step_confirm_discovery()
+
+
+    async def async_step_confirm_discovery(self, user_input=None):
+        """Confirm addition of discovered device."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=f"Local device: {self.local_name}",
+                data={
+                    "host": self.local_device.device_addr,
+                    "local": True,
+                }
+            )
+
+        return self.async_show_form(
+            step_id="confirm_discovery",
+            errors={},
+            description_placeholders={
+                "name": self.local_name,
+            },
+        )
+
+
 
     async def async_step_import(self, conf: dict):
         """Import a configuration from config.yaml."""
         if self.hass.config_entries.async_entries(DOMAIN):
             return self.async_abort(reason="already_setup")
 
-        _, error = await self._check_connection(conf[CONF_HOSTS])
+        user, error = await self._check_connection(conf[CONF_ACCESS_TOKEN])
         if error is not None:
             return self.async_abort(reason=error)
 
+        await self.async_set_unique_id(user.email)
+        self._abort_if_unique_id_configured()
+
         return self.async_create_entry(
-            title="Awair Local Sensors",
-            data={CONF_HOSTS: conf[CONF_HOSTS]},
+            title=f"{user.email} ({user.user_id})",
+            data={
+                CONF_ACCESS_TOKEN: conf[CONF_ACCESS_TOKEN],
+                "local": False
+            },
         )
 
     async def async_step_user(self, user_input: Optional[dict] = None):
@@ -38,39 +92,81 @@ class AwairFlowHandler(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            devices, error = await self._check_connection(user_input[CONF_HOSTS])
+            user, error = await self._check_connection(user_input[CONF_ACCESS_TOKEN])
 
-            if devices is not None:
-                title = "Awair Local Sensors"
-                return self.async_create_entry(title=title, data=user_input)
+            if user is not None:
+                await self.async_set_unique_id(user.email)
+                self._abort_if_unique_id_configured()
 
-            if error != "auth":
+                title = f"{user.email} ({user.user_id})"
+                return self.async_create_entry(title=title, data={**user_input, "local": False})
+
+            if error != "invalid_access_token":
                 return self.async_abort(reason=error)
 
-            errors = {CONF_HOSTS: "auth"}
+            errors = {CONF_ACCESS_TOKEN: "invalid_access_token"}
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_HOSTS): str}),
+            data_schema=vol.Schema({vol.Required(CONF_ACCESS_TOKEN): str}),
             errors=errors,
         )
 
-    async def _check_connection(self, device_addrs_str: str):
+    async def async_step_reauth(self, user_input: Optional[dict] = None):
+        """Handle re-auth if token invalid."""
+        errors = {}
+
+        if user_input is not None:
+            access_token = user_input[CONF_ACCESS_TOKEN]
+            _, error = await self._check_connection(access_token)
+
+            if error is None:
+                for entry in self._async_current_entries():
+                    if entry.unique_id == self.unique_id:
+                        self.hass.config_entries.async_update_entry(
+                            entry, data={**user_input, "local": False}
+                        )
+
+                        return self.async_abort(reason="reauth_successful")
+
+            if error != "invalid_access_token":
+                return self.async_abort(reason=error)
+
+            errors = {CONF_ACCESS_TOKEN: error}
+
+        return self.async_show_form(
+            step_id="reauth",
+            data_schema=vol.Schema({vol.Required(CONF_ACCESS_TOKEN): str}),
+            errors=errors,
+        )
+
+    async def _check_connection(self, access_token: str):
         """Check the access token is valid."""
-        device_addrs = [addr.strip() for addr in device_addrs_str.split(",")]
         session = async_get_clientsession(self.hass)
-        awair = AwairLocal(session=session, device_addrs=device_addrs)
+        awair = Awair(access_token=access_token, session=session)
 
         try:
-            devices = await awair.devices()
+            user = await awair.user()
+            devices = await user.devices()
             if not devices:
-                return (None, "no_devices")
+                return (None, "no_devices_found")
 
-            if len(devices) != len(device_addrs):
-                return (None, "not enough devices")
+            return (user, None)
 
-            return (devices[0], None)
-
+        except AuthError:
+            return (None, "invalid_access_token")
         except AwairError as err:
             LOGGER.error("Unexpected API error: %s", err)
             return (None, "unknown")
+
+    async def _get_local_info(self, ip_addr: str):
+        """Get local Awair device info."""
+        session = async_get_clientsession(self.hass)
+        awair = AwairLocal(session=session, device_addrs=[ip_addr])
+
+        try:
+            devices = await awair.devices()
+            return devices[0]
+        except AwairError as err:
+            LOGGER.error("Unexpected API error: %s", err)
+            return None

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
-  "domain": "awair_local",
-  "name": "Awair Local",
-  "documentation": "https://www.home-assistant.io/integrations/awair_local",
-  "requirements": ["python-awair-local-sensors==0.2.1"],
-  "codeowners": ["@ahayworth", "@bobby", "@danielsjf"],
-  "config_flow": true
+  "domain": "awair",
+  "name": "Awair",
+  "documentation": "https://www.home-assistant.io/integrations/awair",
+  "requirements": ["python_awair==0.2.1"],
+  "codeowners": ["@ahayworth", "@danielsjf"],
+  "config_flow": true,
+  "zeroconf": [{ "type": "_http._tcp.local." }]
 }

--- a/strings.json
+++ b/strings.json
@@ -1,13 +1,33 @@
 {
   "config": {
-    "step": {},
+    "flow_title": "{name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Do you want to set up {name}?"
+      },
+      "user": {
+        "description": "You must register for an Awair developer access token at: https://developer.getawair.com/onboard/login",
+        "data": {
+          "access_token": "[%key:common::config_flow::data::access_token%]",
+          "email": "[%key:common::config_flow::data::email%]"
+        }
+      },
+      "reauth": {
+        "description": "Please re-enter your Awair developer access token.",
+        "data": {
+          "access_token": "[%key:common::config_flow::data::access_token%]",
+          "email": "[%key:common::config_flow::data::email%]"
+        }
+      }
+    },
     "error": {
-      "auth": "[%key:common::config_flow::error::invalid_access_token%]",
-      "unknown": "Unknown Awair API error."
+      "invalid_access_token": "[%key:common::config_flow::error::invalid_access_token%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
-      "no_devices": "[%key:common::config_flow::abort::no_devices_found%]"
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   }
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,15 +1,19 @@
 {
     "config": {
+        "flow_title": "{name}",
         "abort": {
             "already_configured": "Account is already configured",
-            "no_devices": "No devices found on the network",
-            "reauth_successful": "Access Token updated successfully"
+            "no_devices_found": "No devices found on the network",
+            "reauth_successful": "Re-authentication was successful"
         },
         "error": {
-            "auth": "Invalid access token",
-            "unknown": "Unknown Awair API error."
+            "invalid_access_token": "Invalid access token",
+            "unknown": "Unexpected error"
         },
         "step": {
+            "confirm_discovery": {
+              "description": "Do you want to set up {name}?"
+            },
             "reauth": {
                 "data": {
                     "access_token": "Access Token",


### PR DESCRIPTION
This commit is a mostly-working implementation of an integrated
remote+local setup. Details:
- Local setup relies on MDNS/Zeroconf discovery; there is no support for
  statically specifying hosts.
- Local and Remote devices are currently set up as the same
  homeassistant device, which is annoying for various reasons.

The intended flow is that a user either:
- Has never configured remote support at all, and relies solely on
  zeroconf discovery and the config flow kicked off from discovery
- Has configured remote support before, but has disabled remote devices
  they wish to poll locally *before* entering the config flow kicked off
  from discovery
- Has removed the instance of the integration configured with remote
  support entirely

It's a little messy if you set up both local *and* remote
simultaneously for the same Awair device. It *works*! But you can't ever
really disable remote and/or local support once you get into that state - you're stuck with both until you remove the integration.

I think this is just a starting point, but I wanted to push something up
for consideration before I went too much further. What I'd like to do
next is:
- Track remote + local device UUIDs in config_entries somehow
- Set up an Options flow for the integration so that you can toggle
  remote/local polling for devices that can do both
- Automatically upgrade config entries to track preferences for
  remote/local polling when the integrations are set up.

The major barriers to improvements are:
- The discovery flow is not ever supposed to modify configuration
  without consent, which makes some things difficult (or really, just
  means we have to set up more UI flow configs and I dislike doing
  programmatic UI configs like this!)
- We're not really guaranteed that setup/discovery will run in any
  specific order, but we can probably not worry about that too much.
- There doesn't seem to be much of a pattern within HA so far of
  updating config entries during platform setup. I'm worried we'd be
  doing something that's not implicitly supported.

If we can overcome the usability problems, then I think this has a
really nice future. Otherwise I think we should actually revert and go
the route of two separate integrations (but as expressed elsewhere, I
think that has its own flaws).

If you pull this into your HA installation, you'll need to modify the
`generated/zeroconf.py` file like so:

```diff
@@ -75,6 +75,10 @@ ZEROCONF = {
         }
     ],
     "_http._tcp.local.": [
+        {
+            "domain": "awair",
+            "name": "awair*"
+        },
         {
             "domain": "shelly",
             "name": "shelly*"
```

..otherwise HA will never discover the Awair.
